### PR TITLE
Fix error message from rasterio not finding gdal

### DIFF
--- a/src/movementCategoriesTransformer.py
+++ b/src/movementCategoriesTransformer.py
@@ -4,6 +4,7 @@
 
 # Set up -----------------------------------------------------------------------
 
+from osgeo import gdal
 import pysyncrosim as ps
 import pandas as pd
 import os

--- a/src/omniscapeEnvironmentv2.yml
+++ b/src/omniscapeEnvironmentv2.yml
@@ -134,4 +134,4 @@ dependencies:
   - xz=5.2.6=h8d14728_0
   - zlib=1.3.1=h2466b09_1
   - zstd=1.5.6=h0ea2cb4_0
-prefix: C:\Users\CarinaFirkowski\miniconda3\envs\omniscapeEnvironmentv2
+  - gdal=3.9.1

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -2,6 +2,7 @@
 
 # Set up -----------------------------------------------------------------------
 
+from osgeo import gdal
 import pysyncrosim as ps
 import pandas as pd
 import sys
@@ -147,7 +148,7 @@ if not 'julia.exe' in juliaConfig.juliaPath.item():
 if requiredData.resistanceFile.item() != requiredData.resistanceFile.item():
     sys.exit("'Resistance file' is required.")
 
-resistanceLayer = rasterio.open(requiredDataValidation.resistance_file[0])
+resistanceLayer = rasterio.open(requiredDataValidation.resistanceFile[0])
 dataRaster = resistanceLayer.read()
 unique, counts = np.unique(dataRaster, return_counts = True)
 unique = pd.DataFrame(unique)

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package name="omniscape" displayName="Omniscape" description="Omni-directional habitat connectivity based on circuit theory" url="https://apexrms.github.io/omniscape/" version="2.1.1">
+<package name="omniscape" displayName="Omniscape" description="Omni-directional habitat connectivity based on circuit theory" url="https://apexrms.github.io/omniscape/" version="2.1.2">
             
       <dataSheet name="juliaConfiguration" displayName="Julia Configuration" dataScope="Library" isSingleRow="True">
           <column name="juliaPath" displayName="Julia executable" dataType="String" isExternalFile="True" allowDbNull="False" externalFileAbsolute="True" />
@@ -103,7 +103,7 @@
       programName="python" 
       programArguments="omniscapeTransformer.py" 
       condaEnv="omniscapeEnvironmentv2.yml"
-      condaEnvVersion="1">
+      condaEnvVersion="2">
         <dataSheet name="ResistanceOptions" type="Input" />
         <dataSheet name="Required" type="Input" />
         <dataSheet name="outputSpatial" type="Output" />
@@ -124,7 +124,7 @@
       programName="python" 
       programArguments="movementCategoriesTransformer.py" 
       condaEnv="omniscapeEnvironmentv2.yml"
-      condaEnvVersion="1">
+      condaEnvVersion="2">
         <dataSheet name="reclassificationThresholds" type="Input" />
         <dataSheet name="outputTabularReclassification" type="Output" />
         <dataSheet name="outputSpatialMovement" type="Output" />


### PR DESCRIPTION
If you try to run the omniscape template right now, you get the following error: 

![image](https://github.com/user-attachments/assets/d8e04876-95e5-4e03-b1c1-919ad311bb94)

This is happening because rasterio is trying to load the wrong version of gdal. If you import gdal before rasterio in the python script, then rasterio won't try to load the wrong version of gdal. To do this, I had to also update the conda environment to install gdal 3.9.1. 

I also made a fix to one of the column names in the omniscapeTransformer script (it still had the underscore).