### PR TITLE
Af resistance modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ omniscape
 
 # Template libraries
 /src/templates
-
+/Testing
 

--- a/src/helperFunctions.py
+++ b/src/helperFunctions.py
@@ -396,20 +396,21 @@ def apply_resistance_modifier(resistance_path, modifier_path, modifier_table,
         mod_nodata = mod_src.nodata
 
     mod_mask = (modifier_data == mod_nodata) if mod_nodata is not None else np.zeros_like(modifier_data, dtype=bool)
+    focal_input = np.where(mod_mask, np.nan, modifier_data)
 
     if focal_radius is not None and focal_radius > 0:
         size = 2 * focal_radius + 1
-        padded = np.pad(modifier_data, focal_radius, mode='edge')
+        padded = np.pad(focal_input, focal_radius, mode='constant', constant_values=np.nan)
         windows = sliding_window_view(padded, (size, size))
         fn = focal_function.lower()
         if fn == "mean":
-            modifier_data = windows.mean(axis=(-2, -1))
+            modifier_data = np.nanmean(windows, axis=(-2, -1))
         elif fn == "sum":
-            modifier_data = windows.sum(axis=(-2, -1))
+            modifier_data = np.nansum(windows, axis=(-2, -1))
         elif fn == "max":
-            modifier_data = windows.max(axis=(-2, -1))
+            modifier_data = np.nanmax(windows, axis=(-2, -1))
         elif fn == "min":
-            modifier_data = windows.min(axis=(-2, -1))
+            modifier_data = np.nanmin(windows, axis=(-2, -1))
 
     multiplier_array = np.ones_like(resistance_data, dtype=np.float64)
     for _, row in modifier_table.iterrows():

--- a/src/helperFunctions.py
+++ b/src/helperFunctions.py
@@ -363,3 +363,68 @@ def merge_tile_outputs(tile_output_paths, final_output_path, full_extent_info):
         os.remove(vrt_path)
 
     ps.environment.update_run_log(f"Merge complete: {os.path.basename(final_output_path)}")
+
+
+# ============================================================================
+# RESISTANCE MODIFIER
+# ============================================================================
+
+def apply_resistance_modifier(resistance_path, modifier_path, modifier_table,
+                               focal_radius=None, focal_function="mean", output_path=None):
+    """
+    Multiply resistance values by a per-pixel multiplier derived from a secondary raster.
+
+    For each pixel:
+      1. Read modifier raster value (optionally aggregated via focal window first)
+      2. Look up multiplier: first range where minValue <= value < maxValue
+      3. Multiply resistance by that multiplier (pixels matching no range use 1.0)
+
+    The modifier raster must share the CRS of the resistance raster. In tiled mode the
+    full modifier raster path is passed and windowed reading clips it to the tile extent.
+    """
+    from numpy.lib.stride_tricks import sliding_window_view
+
+    with rasterio.open(resistance_path) as res_src:
+        resistance_data = res_src.read(1).astype(np.float64)
+        res_meta = res_src.meta.copy()
+        res_nodata = res_src.nodata
+        tile_bounds = res_src.bounds
+
+    with rasterio.open(modifier_path) as mod_src:
+        window = mod_src.window(*tile_bounds)
+        modifier_data = mod_src.read(1, window=window).astype(np.float64)
+        mod_nodata = mod_src.nodata
+
+    mod_mask = (modifier_data == mod_nodata) if mod_nodata is not None else np.zeros_like(modifier_data, dtype=bool)
+
+    if focal_radius is not None and focal_radius > 0:
+        size = 2 * focal_radius + 1
+        padded = np.pad(modifier_data, focal_radius, mode='edge')
+        windows = sliding_window_view(padded, (size, size))
+        fn = focal_function.lower()
+        if fn == "mean":
+            modifier_data = windows.mean(axis=(-2, -1))
+        elif fn == "sum":
+            modifier_data = windows.sum(axis=(-2, -1))
+        elif fn == "max":
+            modifier_data = windows.max(axis=(-2, -1))
+        elif fn == "min":
+            modifier_data = windows.min(axis=(-2, -1))
+
+    multiplier_array = np.ones_like(resistance_data, dtype=np.float64)
+    for _, row in modifier_table.iterrows():
+        mask = (~mod_mask) & (modifier_data >= row['minValue']) & (modifier_data < row['maxValue'])
+        multiplier_array[mask] = float(row['multiplier'])
+
+    modified = resistance_data * multiplier_array
+    if res_nodata is not None:
+        modified[resistance_data == res_nodata] = res_nodata
+
+    if output_path is None:
+        output_path = resistance_path.replace('.tif', '_modified.tif')
+
+    res_meta.update(dtype='float32', compress='lzw')
+    with rasterio.open(output_path, 'w', **res_meta) as dst:
+        dst.write(modified.astype(np.float32), 1)
+
+    return output_path

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -459,6 +459,12 @@ if applyModifier:
         with rasterio.open(mod_file) as mod_src:
             if mod_src.crs != resistanceLayer.crs:
                 sys.exit(f"Modifier raster '{mod_name}' must have the same CRS as 'Resistance file'.")
+            if mod_src.res != resistanceLayer.res:
+                sys.exit(f"Modifier raster '{mod_name}' resolution {mod_src.res} does not match resistance raster resolution {resistanceLayer.res}.")
+            rb = resistanceLayer.bounds
+            mb = mod_src.bounds
+            if mb.left > rb.left or mb.right < rb.right or mb.bottom > rb.bottom or mb.top < rb.top:
+                sys.exit(f"Modifier raster '{mod_name}' does not fully cover the resistance raster extent.")
         use_focal = mod_row.get('useFocalWindow') == "Yes"
         if use_focal:
             if pd.isna(mod_row.get('focalRadius')):
@@ -572,7 +578,8 @@ for tile_idx, tile_id in enumerate(tiles_to_process):
             use_focal = mod_row.get('useFocalWindow') == "true"
             focal_radius = int(mod_row['focalRadius']) if use_focal and not pd.isna(mod_row.get('focalRadius')) else None
             focal_fn_raw = mod_row.get('focalFunction')
-            focal_fn = str(focal_fn_raw).lower() if use_focal and not pd.isna(focal_fn_raw) else "mean"
+            _focal_fn_map = {0: "mean", 1: "sum", 2: "max", 3: "min"}
+            focal_fn = _focal_fn_map.get(int(focal_fn_raw), "mean") if use_focal and not pd.isna(focal_fn_raw) else "mean"
 
             mod_table = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_row['Name']]
 
@@ -910,15 +917,19 @@ write_modified = (
 )
 if write_modified:
     last_mod_idx = len(resistanceModifiers) - 1
-    if is_tiling:
+    if is_tiling and mode == "loop":
         tile_mod_paths = [
             os.path.join(dataPath, "omniscape_ResistanceModifier", f"tile-{tid}-mod{last_mod_idx}-resistance.tif")
             for tid in tiles_to_process
         ]
         merged_mod_path = os.path.join(dataPath, "omniscape_ResistanceModifier", "resistance-modified.tif")
-        merge_tile_outputs(tile_mod_paths, merged_mod_path)
+        merge_tile_outputs(tile_mod_paths, merged_mod_path, manifest['full_extent'])
         myOutput.modifiedResistance = pd.Series(merged_mod_path)
-        ps.environment.update_run_log(f"  Added modifiedResistance output (merged tiles)")
+        ps.environment.update_run_log("  Added modifiedResistance output (merged tiles)")
+    elif is_tiling:
+        ps.environment.update_run_log(
+            "  Deferring modifiedResistance merge until tile aggregation is complete"
+        )
     else:
         mod_path = os.path.join(dataPath, "omniscape_ResistanceModifier", f"mod{last_mod_idx}-resistance.tif")
         if os.path.exists(mod_path):

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -113,6 +113,11 @@ outputOptions = myScenario.datasheets(name = "omniscape_OutputOptions")
 multiprocessing = myScenario.datasheets(name = "core_Multiprocessing")
 tilingOptions = myScenario.datasheets(name = "omniscape_TilingOptions")
 juliaConfig = myLibrary.datasheets(name = "core_JlConfig")  # Julia config is now at library level
+resistanceModifiers = myScenario.datasheets(name = "omniscape_ResistanceModifiers", show_full_paths=True)
+resistanceModifierTable = myScenario.datasheets(name = "omniscape_ResistanceModifierTable")
+resistanceModifierOptions = myScenario.datasheets(name = "omniscape_ResistanceModifierOptions")
+
+applyModifier = not resistanceModifiers.empty
 
 # ============================================================================
 # LOAD TILE MANIFEST AND DETERMINE EXECUTION MODE
@@ -444,6 +449,22 @@ if not futureConditions.empty:
     if futureConditions.compareToFuture.item() == "both" and (futureConditions.condition1FutureFile.item() != futureConditions.condition1FutureFile.item() or futureConditions.condition2FutureFile.item() != futureConditions.condition2FutureFile.item()):
         sys.exit("'Compare to future' was set to 'both', therefore 'Condition 1 future file' and 'Condition 2 future file' are required.")
 
+if applyModifier:
+    for _, mod_row in resistanceModifiers.iterrows():
+        mod_name = mod_row['Name']
+        mod_file = mod_row['modifierFile']
+        if not os.path.isfile(mod_file):
+            sys.exit(f"Modifier raster '{mod_name}' not found: {mod_file}")
+        with rasterio.open(mod_file) as mod_src:
+            if mod_src.crs != resistanceLayer.crs:
+                sys.exit(f"Modifier raster '{mod_name}' must have the same CRS as 'Resistance file'.")
+        use_focal = mod_row.get('useFocalWindow') == "Yes"
+        if use_focal:
+            if pd.isna(mod_row.get('focalRadius')):
+                sys.exit(f"'Focal radius' is required for modifier '{mod_name}' when 'Use focal window' is enabled.")
+        mod_rows = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_name]
+        if mod_rows.empty:
+            sys.exit(f"'Modifier Lookup Table' has no rows for modifier '{mod_name}'.")
 
 
 # Change "Yes" and "No" to "true" and "false" ----------------------------------
@@ -453,6 +474,8 @@ resistanceOptions = resistanceOptions.replace({'Yes': 'true', 'No': 'false'})
 conditionalOptions = conditionalOptions.replace({'Yes': 'true', 'No': 'false'})
 outputOptions = outputOptions.replace({'Yes': 'true', 'No': 'false'})
 multiprocessing = multiprocessing.replace({'Yes': 'true', 'No': 'false'})
+resistanceModifiers = resistanceModifiers.replace({'Yes': 'true', 'No': 'false'})
+resistanceModifierOptions = resistanceModifierOptions.replace({'Yes': 'true', 'No': 'false'})
 
 
 
@@ -532,6 +555,35 @@ for tile_idx, tile_id in enumerate(tiles_to_process):
         resistance_file_path = requiredDataValidation.resistanceFile.item()
         source_file_path = requiredDataValidation.sourceFile.item() if not pd.isna(requiredDataValidation.sourceFile.item()) else "None"
         project_name = os.path.join(dataPath, "omniscape_outputSpatial")
+
+    # ========================================================================
+    # APPLY RESISTANCE MODIFIER (if configured)
+    # ========================================================================
+
+    if applyModifier:
+        modifier_dir = os.path.join(dataPath, "omniscape_ResistanceModifier")
+        os.makedirs(modifier_dir, exist_ok=True)
+
+        for mod_idx, (_, mod_row) in enumerate(resistanceModifiers.iterrows()):
+            fname_base = f"tile-{tile_id}-mod{mod_idx}" if is_tiling else f"mod{mod_idx}"
+            mod_output_path = os.path.join(modifier_dir, f"{fname_base}-resistance.tif")
+
+            focal_fn_map = {0: "mean", 1: "sum", 2: "max", 3: "min"}
+            use_focal = mod_row.get('useFocalWindow') == "true"
+            focal_radius = int(mod_row['focalRadius']) if use_focal and not pd.isna(mod_row.get('focalRadius')) else None
+            focal_fn = focal_fn_map.get(int(mod_row.get('focalFunction', 0)), "mean") if use_focal else "mean"
+
+            mod_table = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_row['Name']]
+
+            resistance_file_path = apply_resistance_modifier(
+                resistance_path=resistance_file_path,
+                modifier_path=mod_row['modifierFile'],
+                modifier_table=mod_table,
+                focal_radius=focal_radius,
+                focal_function=focal_fn,
+                output_path=mod_output_path
+            )
+            ps.environment.update_run_log(f"Applied modifier '{mod_row['Name']}' → {mod_output_path}")
 
     # ========================================================================
     # GENERATE CONFIG.INI FOR THIS TILE
@@ -849,6 +901,28 @@ else:
     ps.environment.update_run_log(f"  Added classifiedResistance output (original)")
 
 
+
+write_modified = (
+    applyModifier
+    and not resistanceModifierOptions.empty
+    and resistanceModifierOptions.writeModifiedResistance.item() == "true"
+)
+if write_modified:
+    last_mod_idx = len(resistanceModifiers) - 1
+    if is_tiling:
+        tile_mod_paths = [
+            os.path.join(dataPath, "omniscape_ResistanceModifier", f"tile-{tid}-mod{last_mod_idx}-resistance.tif")
+            for tid in tiles_to_process
+        ]
+        merged_mod_path = os.path.join(dataPath, "omniscape_ResistanceModifier", "resistance-modified.tif")
+        merge_tile_outputs(tile_mod_paths, merged_mod_path)
+        myOutput.modifiedResistance = pd.Series(merged_mod_path)
+        ps.environment.update_run_log(f"  Added modifiedResistance output (merged tiles)")
+    else:
+        mod_path = os.path.join(dataPath, "omniscape_ResistanceModifier", f"mod{last_mod_idx}-resistance.tif")
+        if os.path.exists(mod_path):
+            myOutput.modifiedResistance = pd.Series(mod_path)
+            ps.environment.update_run_log(f"  Added modifiedResistance output")
 
 # Save outputs to SyncroSim ---------------------------------------------------------------------
 

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -771,6 +771,25 @@ for tile_idx, tile_id in enumerate(tiles_to_process):
                     os.rename(cropped_path, buffered_path)
                     ps.environment.update_run_log(f"  Removed buffer from {output_file}")
 
+            if applyModifier:
+                for mod_idx in range(len(resistanceModifiers)):
+                    mod_path = os.path.join(
+                        dataPath, "omniscape_ResistanceModifier",
+                        f"tile-{tile_id}-mod{mod_idx}-resistance.tif"
+                    )
+                    if os.path.exists(mod_path):
+                        cropped_path = mod_path.replace('.tif', '_cropped.tif')
+                        crop_buffer_from_output(
+                            mod_path,
+                            cropped_path,
+                            tile_info['original_extent'],
+                            manifest['buffer_pixels'],
+                            tile_info.get('buffered_extent')
+                        )
+                        os.remove(mod_path)
+                        os.rename(cropped_path, mod_path)
+                        ps.environment.update_run_log(f"  Removed buffer from modifier tile mod{mod_idx}")
+
         # Handle mode-specific post-processing
         if mode == "multiprocessing":
             # Extend tiles to full extent for SyncroSim merging

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -578,8 +578,8 @@ for tile_idx, tile_id in enumerate(tiles_to_process):
             use_focal = mod_row.get('useFocalWindow') == "true"
             focal_radius = int(mod_row['focalRadius']) if use_focal and not pd.isna(mod_row.get('focalRadius')) else None
             focal_fn_raw = mod_row.get('focalFunction')
-            _focal_fn_map = {0: "mean", 1: "sum", 2: "max", 3: "min"}
-            focal_fn = _focal_fn_map.get(int(focal_fn_raw), "mean") if use_focal and not pd.isna(focal_fn_raw) else "mean"
+            _focal_fn_map = {"0": "mean", "1": "sum", "2": "max", "3": "min"}
+            focal_fn = _focal_fn_map.get(str(focal_fn_raw), str(focal_fn_raw).lower()) if use_focal and not pd.isna(focal_fn_raw) else "mean"
 
             mod_table = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_row['Name']]
 

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -467,7 +467,7 @@ if applyModifier:
                 sys.exit(f"Modifier raster '{mod_name}' does not fully cover the resistance raster extent.")
         use_focal = mod_row.get('useFocalWindow') == "Yes"
         if use_focal:
-            if pd.isna(mod_row.get('focalRadius')):
+            if pd.isna(mod_row.get('focalRadius')) or int(mod_row.get('focalRadius')) <= 0:  
                 sys.exit(f"'Focal radius' is required for modifier '{mod_name}' when 'Use focal window' is enabled.")
         mod_rows = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_name]
         if mod_rows.empty:
@@ -953,7 +953,7 @@ if write_modified:
         mod_path = os.path.join(dataPath, "omniscape_ResistanceModifier", f"mod{last_mod_idx}-resistance.tif")
         if os.path.exists(mod_path):
             myOutput.modifiedResistance = pd.Series(mod_path)
-            ps.environment.update_run_log(f"  Added modifiedResistance output")
+            ps.environment.update_run_log("  Added modifiedResistance output")
 
 # Save outputs to SyncroSim ---------------------------------------------------------------------
 

--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -22,7 +22,8 @@ from helperFunctions import (
     crop_buffer_from_output,
     extend_tile_to_full_extent,
     merge_tile_outputs,
-    safe_progress_bar
+    safe_progress_bar,
+    apply_resistance_modifier
 )
 
 # Global variable to track Julia process for cleanup
@@ -568,10 +569,10 @@ for tile_idx, tile_id in enumerate(tiles_to_process):
             fname_base = f"tile-{tile_id}-mod{mod_idx}" if is_tiling else f"mod{mod_idx}"
             mod_output_path = os.path.join(modifier_dir, f"{fname_base}-resistance.tif")
 
-            focal_fn_map = {0: "mean", 1: "sum", 2: "max", 3: "min"}
             use_focal = mod_row.get('useFocalWindow') == "true"
             focal_radius = int(mod_row['focalRadius']) if use_focal and not pd.isna(mod_row.get('focalRadius')) else None
-            focal_fn = focal_fn_map.get(int(mod_row.get('focalFunction', 0)), "mean") if use_focal else "mean"
+            focal_fn_raw = mod_row.get('focalFunction')
+            focal_fn = str(focal_fn_raw).lower() if use_focal and not pd.isna(focal_fn_raw) else "mean"
 
             mod_table = resistanceModifierTable[resistanceModifierTable['modifier'] == mod_row['Name']]
 

--- a/src/package.xml
+++ b/src/package.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<package name="omniscape" displayName="Omniscape" description="Omni-directional habitat connectivity based on circuit theory" url="https://apexrms.github.io/omniscape/" version="2.6.0" minSyncroSimVersion="3.1.0">
+<package name="omniscape" displayName="Omniscape" description="Omni-directional habitat connectivity based on circuit theory" url="https://apexrms.github.io/omniscape/" version="2.7.0" minSyncroSimVersion="3.1.0">
 
       <dataSheet name="movementTypes" displayName="Connectivity Categories" dataScope="Project" displayMember="Name">
           <column name="Name" dataType="String" />
@@ -35,6 +35,25 @@
       <dataSheet name="ReclassTable" displayName="Reclass Table">
           <column name="landCover" displayName="Land cover class ID" dataType="Integer" validationType="WholeNumber" validationCondition="None" />
           <column name="resistanceValue" displayName="Resistance value" dataType="Double" validationType="Decimal" validationCondition="None" />
+      </dataSheet>
+
+      <dataSheet name="ResistanceModifiers" displayName="Resistance Modifiers">
+          <column name="Name" displayName="Name" dataType="String" />
+          <column name="modifierFile" displayName="Modifier raster" dataType="String" isExternalFile="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif|All Files (*.*)|*.*" isRaster="True" />
+          <column name="useFocalWindow" displayName="Use focal window" dataType="Boolean" isOptional="True" defaultValue="0" description="Aggregate the modifier raster within a moving window before applying the lookup table." />
+          <column name="focalRadius" displayName="Focal radius (pixels)" dataType="Integer" validationType="WholeNumber" validationCondition="Greater" formula1="0" isOptional="True" description="Radius in pixels for the focal window. Required when Use focal window is enabled." />
+          <column name="focalFunction" displayName="Focal function" dataType="Integer" validationType="List" formula1="0:Mean|1:Sum|2:Max|3:Min" isOptional="True" defaultValue="0" />
+      </dataSheet>
+
+      <dataSheet name="ResistanceModifierTable" displayName="Modifier Lookup Table">
+          <column name="modifier" displayName="Modifier name" dataType="String" description="Must match a Name in the Resistance Modifiers table." />
+          <column name="minValue" displayName="Min modifier value" dataType="Double" validationType="Decimal" validationCondition="None" />
+          <column name="maxValue" displayName="Max modifier value" dataType="Double" validationType="Decimal" validationCondition="None" />
+          <column name="multiplier" displayName="Resistance multiplier" dataType="Double" validationType="Decimal" validationCondition="Greater" formula1="0" description="Value by which to multiply resistance. 1.0 = no change." />
+      </dataSheet>
+
+      <dataSheet name="ResistanceModifierOptions" displayName="Options" isSingleRow="True">
+          <column name="writeModifiedResistance" displayName="Write modified resistance" dataType="Boolean" isOptional="True" defaultValue="0" description="Output the final modified resistance raster after all modifiers are applied." />
       </dataSheet>
 
       <dataSheet name="OutputOptions" displayName="Output Options" isSingleRow="True">
@@ -85,6 +104,7 @@
           <column name="flowPotential" displayName="Flow potential" dataType="String" isExternalFile="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif|All Files (*.*)|*.*" isRaster="True" />
           <column name="normalizedCumCurrmap" displayName="Normalized current flow" dataType="String" isExternalFile="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif|All Files (*.*)|*.*" isRaster="True" />
           <column name="classifiedResistance" displayName="Classified resistance" dataType="String" isExternalFile="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif|All Files (*.*)|*.*" isRaster="True" />
+          <column name="modifiedResistance" displayName="Modified resistance" dataType="String" isExternalFile="True" externalFileFilter="GeoTIFF Files (*.tif)|*.tif|All Files (*.*)|*.*" isRaster="True" />
       </dataSheet>
 
       <dataSheet name="outputSpatialMovement" displayName="Connectivity Categories" isSingleRow="True">
@@ -133,6 +153,9 @@
         <dataSheet name="Condition2" type="Input" />
         <dataSheet name="Condition1" type="Input" />
         <dataSheet name="ReclassTable" type="Input" />
+        <dataSheet name="ResistanceModifiers" type="Input" />
+        <dataSheet name="ResistanceModifierTable" type="Input" />
+        <dataSheet name="ResistanceModifierOptions" type="Input" />
     </transformer>
 
     <transformer
@@ -162,6 +185,11 @@
         <group name="Resistance0Reclassification" displayName="Resistance Reclassification">
           <item name="ResistanceOptions" />
           <item name="ReclassTable" />
+        </group>
+        <group name="Resistance0Modifier" displayName="Resistance Modifier">
+          <item name="ResistanceModifierOptions" />
+          <item name="ResistanceModifiers" />
+          <item name="ResistanceModifierTable" />
         </group>
         <item name="OutputOptions" />
         <group name="Conditional0Connectivity" displayName="Conditional Connectivity">
@@ -196,6 +224,7 @@
       <group name="Inputs" displayName="Inputs">
         <item name="RequiredSourceFile" displayName="Sources" dataSheet="Required" column="sourceFile" />
         <item name="outputSpatialClassifiedResistance" displayName="Resistance" dataSheet="outputSpatial" column="classifiedResistance" />
+        <item name="outputSpatialModifiedResistance" displayName="Modified resistance" dataSheet="outputSpatial" column="modifiedResistance" />
       </group>
       <group name="Outputs" displayName="Outputs">
         <item name="outputSpatialCumCurrmap" displayName="Cumulative current flow" dataSheet="outputSpatial" column="cumCurrmap" />

--- a/src/updates/update-2.7.xml
+++ b/src/updates/update-2.7.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<update comment="Update to omniscape 2.7 that adds resistance modifier support">
+
+    <!-- Add modifiedResistance output column to the existing outputSpatial table.
+         New tables (ResistanceModifiers, ResistanceModifierTable, ResistanceModifierOptions)
+         are created automatically by SyncroSim schema migration. -->
+    <action code="Exec" condition="TableExists" criteria="omniscape_outputSpatial">
+        <item>ALTER TABLE omniscape_outputSpatial ADD COLUMN modifiedResistance TEXT</item>
+    </action>
+
+</update>


### PR DESCRIPTION
Added ability to modify resistance rasters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resistance modifier workflow to apply configurable multiplier rasters to resistance inputs, with lookup-table range mapping, optional focal-window aggregation, and per-run/tiling handling.
  * New optional "Modified resistance" spatial output that can be produced/merged depending on run/tiling mode.

* **Chores**
  * Package version bumped to 2.7.0.
  * Updated ignore rules to exclude a Testing directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->