### PR TITLE
added label for land cover class

### DIFF
--- a/src/omniscapeTransformer.py
+++ b/src/omniscapeTransformer.py
@@ -497,7 +497,7 @@ if not reclassTable.empty and (reclassTable != "None").values.any():
     #reclassTable.resistanceValue = reclassTable.resistanceValue.astype(str)
     reclassTable.loc[reclassTable["resistanceValue"] == -9999, "resistanceValue"] = "missing"
     with open(os.path.join(reclassTablePath, "reclass_table.txt"), "w") as f:
-        file = reclassTable.to_string(header=False, index=False)
+        file = reclassTable[["landCover", "resistanceValue"]].to_string(header=False, index=False)
         f.write(file)
 else:
     reclassTablePath = "None"

--- a/src/package.xml
+++ b/src/package.xml
@@ -33,6 +33,7 @@
       </dataSheet>
 
       <dataSheet name="ReclassTable" displayName="Reclass Table">
+          <column name="landCoverLabel" displayName="Land cover class" dataType="String" isOptional="True" validationCondition="None" />
           <column name="landCover" displayName="Land cover class ID" dataType="Integer" validationType="WholeNumber" validationCondition="None" />
           <column name="resistanceValue" displayName="Resistance value" dataType="Double" validationType="Decimal" validationCondition="None" />
       </dataSheet>

--- a/src/updates/update-2.7.xml
+++ b/src/updates/update-2.7.xml
@@ -8,4 +8,10 @@
         <item>ALTER TABLE omniscape_outputSpatial ADD COLUMN modifiedResistance TEXT</item>
     </action>
 
+    <!-- Add optional landCoverLabel column to ReclassTable for user-facing land cover descriptions.
+         This column is display-only and has no effect on the analysis. -->
+    <action code="Exec" condition="TableExists" criteria="omniscape_ReclassTable">
+        <item>ALTER TABLE omniscape_ReclassTable ADD COLUMN landCoverLabel TEXT</item>
+    </action>
+
 </update>


### PR DESCRIPTION
Added text only column to help with description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the reclassification datasheet to include an optional land cover label and added a migration to create the new nullable column.

* **Bug Fixes**
  * Reclassification file generation now outputs only the numeric land cover ID and resistance value columns, ensuring consistent exported table contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->